### PR TITLE
Update json-funcs.jq

### DIFF
--- a/2-agnostic/assets/json-funcs.jq
+++ b/2-agnostic/assets/json-funcs.jq
@@ -21,7 +21,7 @@ def count($array):
 def select_independants($array):
   array |
   to_entries | .[] | 
-  select((.value == -1) or (.value == "-1")) |
+  select((.value <= -1) or (.value == "-1")) |
   .key
   ;
 


### PR DESCRIPTION
There seems to be a bug for processes that have an order lower than -1. These processes are not currently identified as independent, and the value should be <= -1 instead of == -1